### PR TITLE
docs(readme): refresh project direction and workflow docs

### DIFF
--- a/AIEF/context/business/roadmap.md
+++ b/AIEF/context/business/roadmap.md
@@ -7,16 +7,16 @@
 | M0 | 对齐 OpenCode 事件 payload | — | 0.5 day | ✅ 已完成 |
 | M1 | 采集层 MVP — 自动归档会话 | core, archive, providers/opencode, cli | 1–2 days | ✅ 已完成 |
 | M2 | 萃取层 MVP — SDK + demo distiller + file sink | distill, distillers/pitfall-card, sinks/file | 2–4 days | ✅ 已完成 |
-| M3 | 多模型 LLM 路由 | distill/llm-providers/* | 1–2 days | ⏳ 规划中 |
-| M4 | 多数据源接入 | providers/claude-code | 1–2 days | ⏳ 规划中 |
+| M3 | 多模型 LLM 路由 | distill/llm-providers/* | 1–2 days | ✅ 已完成 |
+| M4 | 多数据源接入 | providers/claude-code | 1–2 days | ▶ 下一步 |
 | M5 | 生态化与工作流 | sinks/github, approve-flow, more distillers | Ongoing | ⏳ 规划中 |
 
 ---
 
 ## 当前进度 | Current Progress
 
-截至 2026-03-02，采集链路已完成可运行闭环（插件转发 → daemon 接收 → provider 拉取 → 脱敏 → 原子 JSON 落盘）。  
-As of 2026-03-02, the capture pipeline is fully runnable end-to-end (plugin forward → daemon receive → provider pull → redaction → atomic JSON snapshot write).
+截至 2026-03-09，采集链路与多模型萃取链路都已完成可运行闭环。  
+As of 2026-03-09, both the capture pipeline and the multi-provider distill pipeline are runnable end-to-end.
 
 已完成项 / Completed items:
 
@@ -29,6 +29,9 @@ As of 2026-03-02, the capture pipeline is fully runnable end-to-end (plugin forw
 - `@loamlog/distiller-sdk` 落地：`defineDistiller`、`createEvidence`
 - `@loamlog/distiller-pitfall-card` 与 `@loamlog/sink-file` 落地，支持本地候选输出
 - CLI 新增 `loam distill` 命令，支持 `--distiller/--llm/--since/--until/--test-session`
+- M3 多 provider LLM 路由已落地：OpenAI / Anthropic / DeepSeek / Ollama
+- CLI 已支持 `--llm-timeout-ms`，Router 支持 fallback 与类型化错误
+- GitHub 工作流治理已补齐：`develop` / `master` 受保护，已开启合并后自动删分支
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,10 @@ test(archive): add redaction edge-case coverage
 2. **Target branch**: Always `develop` (except hotfixes → `master`)
 3. **PR title**: Must follow commit convention (e.g., `feat(cli): add list command`)
 4. **PR body**: Use the provided template — fill in every section
-5. **CI must pass**: All checks green before merge
-6. **Squash merge**: Prefer squash merge to keep `develop` history clean
+5. **Protected branches**: `develop` and `master` are protected; use PRs instead of direct pushes in normal flow
+6. **CI must pass**: `Test & Typecheck` must be green before merge
+7. **Merge strategy**: Keep history intentional — squash small/noisy branches, or preserve meaningful atomic commits when that makes review and rollback clearer
+8. **Branch cleanup**: Merged branches are auto-deleted by GitHub
 
 For large changes, open an issue first to discuss approach before writing code.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ Cursor*      ──►  redaction            multi-distiller       notion*
 
 ---
 
+## Current Direction
+
+As of 2026-03-09, Loamlog has moved past the capture-only MVP stage and now has a working multi-provider distill path.
+
+- **M3 is complete** — the distill engine can route across OpenAI, Anthropic, DeepSeek, and Ollama without changing distiller code
+- **Current focus is M4** — add the second provider family beyond OpenCode and prove the provider abstraction at the source layer
+- **M5 remains the product expansion phase** — more distillers, external sinks, and approval-oriented workflow on top of the current local-first engine
+
+---
+
 ## Project Structure
 
 ```
@@ -72,8 +82,8 @@ loamlog/
 | M0 | Validate OpenCode event/payload pipeline | ✅ Completed |
 | M1 | Capture layer MVP — auto-archive sessions | ✅ Completed |
 | M2 | Distill platform MVP — pitfall-card distiller | ✅ Completed |
-| M3 | Multi-model LLM routing | ⏳ Planned |
-| M4 | Multi-source providers (Claude Code, ...) | ⏳ Planned |
+| M3 | Multi-model LLM routing | ✅ Completed |
+| M4 | Multi-source providers (Claude Code, ...) | ▶ Next |
 | M5 | Ecosystem — sinks, approve flow, more distillers | ⏳ Planned |
 
 The capture pipeline is fully runnable end-to-end:
@@ -86,6 +96,15 @@ The distill pipeline is now runnable end-to-end:
 
 ```bash
 loam distill --distiller @loamlog/distiller-pitfall-card --llm deepseek/deepseek-chat
+```
+
+The current router supports provider/model pairs such as:
+
+```bash
+loam distill --llm openai/gpt-4o-mini
+loam distill --llm anthropic/claude-3-5-haiku-latest
+loam distill --llm deepseek/deepseek-chat
+loam distill --llm ollama/llama3.2:3b
 ```
 
 ---
@@ -101,7 +120,7 @@ loam distill --distiller @loamlog/distiller-pitfall-card --llm deepseek/deepseek
 ### Install & Build
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/loamlog.git
+git clone https://github.com/tongsh6/loamlog.git
 cd loamlog
 pnpm install
 pnpm run build
@@ -140,6 +159,13 @@ Add the plugin to your global `~/.config/opencode/opencode.json`:
 - **Logs**: Check `/tmp/loamlog-debug.log` to verify initialization and event capture.
 
 npm: https://www.npmjs.com/package/opencode-loamlog
+
+### Development workflow
+
+- Branches follow `feature/* -> develop -> master`
+- `develop` is the default PR target; `master` is the stable release branch
+- `develop` and `master` are protected; PRs and green `Test & Typecheck` are required in normal flow
+- Merged branches are auto-deleted on GitHub
 
 ### Browse your archive
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -46,6 +46,16 @@ Cursor*      ──►  脱敏处理             多 distiller          notion*
 
 ---
 
+## 当前方向
+
+截至 2026-03-09，Loamlog 已经从“只完成采集 MVP”进入“采集 + 多模型萃取链路可运行”的阶段。
+
+- **M3 已完成**：distill 引擎已可在不改 distiller 代码的前提下切换 OpenAI、Anthropic、DeepSeek、Ollama
+- **当前主焦点是 M4**：接入第二类 AI 数据源，验证 source-provider 抽象在 OpenCode 之外也成立
+- **M5 仍是扩展阶段**：更多 distiller、外部 sink、以及带审批的工作流将在当前本地优先引擎之上展开
+
+---
+
 ## 目录结构
 
 ```
@@ -72,8 +82,8 @@ loamlog/
 | M0 | 验证 OpenCode 事件与 payload 拉取链路 | ✅ 已完成 |
 | M1 | 采集层 MVP — 自动归档会话 | ✅ 已完成 |
 | M2 | 萃取层 MVP — pitfall-card distiller | ✅ 已完成 |
-| M3 | 多模型 LLM 路由 | ⏳ 规划中 |
-| M4 | 多数据源接入（Claude Code 等） | ⏳ 规划中 |
+| M3 | 多模型 LLM 路由 | ✅ 已完成 |
+| M4 | 多数据源接入（Claude Code 等） | ▶ 下一步 |
 | M5 | 生态化 — Sink、审批流、更多 distiller | ⏳ 规划中 |
 
 采集管道已可端到端运行：
@@ -86,6 +96,15 @@ OpenCode 插件 → POST /capture → loam daemon → provider 拉取 → 脱敏
 
 ```bash
 loam distill --distiller @loamlog/distiller-pitfall-card --llm deepseek/deepseek-chat
+```
+
+当前路由器已支持以下 provider/model 组合示例：
+
+```bash
+loam distill --llm openai/gpt-4o-mini
+loam distill --llm anthropic/claude-3-5-haiku-latest
+loam distill --llm deepseek/deepseek-chat
+loam distill --llm ollama/llama3.2:3b
 ```
 
 ---
@@ -140,6 +159,13 @@ npm install -g opencode-loamlog
 - **日志验证**：检查 `/tmp/loamlog-debug.log` 以确认插件初始化和事件捕获状态。
 
 npm: https://www.npmjs.com/package/opencode-loamlog
+
+### 开发工作流
+
+- 分支流转采用 `feature/* -> develop -> master`
+- `develop` 是默认 PR 目标分支，`master` 是稳定发布分支
+- `develop` 和 `master` 当前都受保护，正常流程需要 PR 且 `Test & Typecheck` 为绿色
+- GitHub 已开启已合并分支自动删除
 
 ### 浏览归档
 

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -21,7 +21,7 @@ After installation, ensure the plugin is enabled in your global OpenCode configu
 
 ```json
 {
-  "plugin": ["opencode-loamlog@latest"]
+  "plugins": ["opencode-loamlog@latest"]
 }
 ```
 
@@ -61,11 +61,12 @@ Publishing is handled via GitHub Actions:
   ```
 - **Manual**: Go to GitHub Actions -> "Publish OpenCode Plugin" -> "Run workflow". Select the version bump type (patch/minor/major).
 
-#### 2. Manual Release
-If you have the necessary permissions and `NPM_TOKEN` configured locally:
-```bash
-cd plugins/opencode
-npm publish --access public
-```
+#### 2. Local publishing is forbidden
 
-**Note**: Ensure `NPM_TOKEN` is configured in GitHub Repository Secrets for the automated workflow to work.
+Do not run `npm publish` or `pnpm publish` locally for this plugin.
+
+- All plugin releases must go through GitHub Actions
+- Tag-based releases use the `opencode-loamlog@v*` convention
+- Manual releases, if needed, should be triggered from the "Publish OpenCode Plugin" workflow
+
+**Note**: Ensure `NPM_TOKEN` is configured in GitHub repository secrets for the automated workflow to work.

--- a/plugins/opencode/README.zh.md
+++ b/plugins/opencode/README.zh.md
@@ -21,7 +21,7 @@ npm install -g opencode-loamlog
 
 ```json
 {
-  "plugin": ["opencode-loamlog@latest"]
+  "plugins": ["opencode-loamlog@latest"]
 }
 ```
 
@@ -61,11 +61,12 @@ pnpm run test
   ```
 - **手动触发**：前往 GitHub Actions -> "Publish OpenCode Plugin" -> "Run workflow"。选择版本升级类型（patch/minor/major）。
 
-#### 2. 手动发布
-如果你拥有相应权限且本地配置了 `NPM_TOKEN`：
-```bash
-cd plugins/opencode
-npm publish --access public
-```
+#### 2. 禁止本地发布
+
+不要在本地为该插件执行 `npm publish` 或 `pnpm publish`。
+
+- 所有插件发布都必须通过 GitHub Actions 完成
+- Tag 发布使用 `opencode-loamlog@v*` 约定
+- 如需手动发布，应在 GitHub Actions 中运行 "Publish OpenCode Plugin" 工作流
 
 **注意**：必须在 GitHub 仓库的 Secrets 中配置 `NPM_TOKEN` 才能使自动工作流生效。


### PR DESCRIPTION
## 背景
README 与部分关联文档仍停留在 M2/M3 过渡期的表述，和当前仓库状态存在偏差：
- README 仍将 M3 标记为规划中
- 顶层说明没有体现当前主焦点已经转到 M4
- 插件 README 仍保留本地 `npm publish` 指引
- CONTRIBUTING 没有反映当前已经生效的分支保护和自动删分支设置

## 本次更新
- 更新 `README.md` / `README.zh.md`
  - 明确 M3 已完成
  - 明确当前主焦点为 M4
  - 补充当前支持的 provider/model 示例
  - 补充当前开发工作流说明
  - 修正仓库 clone 地址占位符
- 更新 `plugins/opencode/README.md` / `plugins/opencode/README.zh.md`
  - 修正 OpenCode 配置键为 `plugins`
  - 移除过期的本地发布指引
  - 明确插件发布必须通过 GitHub Actions 完成
- 更新 `AIEF/context/business/roadmap.md`
  - 同步 M3 / M4 状态和当前进展
- 更新 `CONTRIBUTING.md`
  - 同步受保护分支、CI 检查与自动删分支等协作规则

## 验证
- 通过 grep 确认 README 已不再保留 `M3 planned`、`YOUR_USERNAME`、插件本地 `npm publish` 等明显过期内容
- 工作区文档变更范围仅限 6 个文档文件

## 说明
尝试运行 `node AIEF/scripts/check-bilingual-docs.js` 时，发现脚本本身在当前 `type: module` 环境下因 CJS/ESM 配置问题无法直接运行；这属于仓库已有问题，不是本次文档更新引入的。