### PR TITLE
chore(git): ignore .sisyphus agent working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ nul
 
 # Local browser runtime data used by dev-browser skill
 skills/dev-browser/profiles/browser-data/
+
+# Sisyphus AI agent working directory
+.sisyphus/


### PR DESCRIPTION
## Summary

- 将 `.sisyphus/` 加入 `.gitignore`，避免 Sisyphus AI agent 的工作目录被纳入版本控制