### PR TITLE
docs: update README for Milestone A completion

### DIFF
--- a/AIEF/context/business/current-focus.md
+++ b/AIEF/context/business/current-focus.md
@@ -2,10 +2,19 @@
 
 ## 状态总览 | Status Summary
 
-截至 2026-03-10，Loamlog 的 capture、archive、redaction、distill、本地 file sink 主路径都已在仓库中存在并可运行。
-As of 2026-03-10, the capture, archive, redaction, distill, and local file-sink paths all exist in the repository and are runnable.
+截至 2026-03-13，Loamlog 已完成 **Milestone A：可信底盘**，新增了三个关键基础设施：
+As of 2026-03-13, Loamlog has completed **Milestone A: Trust Infrastructure**, adding three critical capabilities:
 
-同时，`claude-code` provider 的主路径实现也已进入仓库，说明“多源 provider 抽象是否成立”这个问题已经拿到初步工程答案。
+1. **Sanitization Gateway** — 日志脱敏硬前置层，确保敏感数据在进入 AI 处理前被安全脱敏
+   Log sanitization gateway ensuring sensitive data is redacted before AI processing
+
+2. **Triggered Intelligence Pipeline** — 阈值触发、异步批处理、性能隔离的智能萃取管道
+   Threshold-based, async, rate-limited intelligence pipeline for efficient distill
+
+3. **Evaluation Harness** — 质量评估框架，验证萃取准确性与行动建议质量
+   Quality evaluation framework validating distill accuracy and action suggestions
+
+同时，`claude-code` provider 的主路径实现也已进入仓库，说明"多源 provider 抽象是否成立"这个问题已经拿到初步工程答案。
 The main `claude-code` provider path has also landed in the repository, which means the project already has an initial engineering answer for whether the multi-source provider abstraction works.
 
 ## 当前产品问题 | Current Product Question

--- a/AIEF/context/business/roadmap.md
+++ b/AIEF/context/business/roadmap.md
@@ -8,6 +8,7 @@
 | M1 | 采集层 MVP — 自动归档会话 | core, archive, providers/opencode, cli | 1–2 days | ✅ 已完成 |
 | M2 | 萃取层 MVP — SDK + demo distiller + file sink | distill, distillers/pitfall-card, sinks/file | 2–4 days | ✅ 已完成 |
 | M3 | 多模型 LLM 路由 | distill/llm-providers/* | 1–2 days | ✅ 已完成 |
+| **Milestone A** | **可信底盘** — 脱敏、触发控制、质量评估 | sanitizer, trigger, evaluation-harness | 2–3 weeks | ✅ **已完成** |
 | M4 | 多数据源接入 | providers/claude-code | 1–2 days | ◐ 主路径已落地，待补强 |
 | M5 | 生态化与工作流 | sinks/github, approve-flow, more distillers | Ongoing | ⏳ 规划中 |
 
@@ -15,8 +16,13 @@
 
 ## 当前进度 | Current Progress
 
-截至 2026-03-10，采集链路与多模型萃取链路都已完成可运行闭环，且 Claude Code provider 的主路径实现已进入仓库。  
-As of 2026-03-10, both the capture pipeline and the multi-provider distill pipeline are runnable end-to-end, and the main Claude Code provider path has landed in the repository.
+截至 2026-03-13，Loamlog 已完成 **Milestone A：可信底盘**，新增了 sanitizer、trigger、evaluation-harness 三个基础设施包。
+As of 2026-03-13, Loamlog has completed **Milestone A: Trust Infrastructure**, adding three foundational packages: sanitizer, trigger, and evaluation-harness.
+
+Milestone A 通过以下 Issues 和 PRs 完成：
+- Issue #26 (Sanitization Gateway) → PR #39 ✅
+- Issue #22 (Triggered Intelligence Pipeline) → PR #41 ✅
+- Issue #23 (Evaluation Harness MVP) → PR #37 ✅
 
 已完成项 / Completed items:
 
@@ -33,6 +39,13 @@ As of 2026-03-10, both the capture pipeline and the multi-provider distill pipel
 - CLI 已支持 `--llm-timeout-ms`，Router 支持 fallback 与类型化错误
 - `packages/providers/claude-code` 与 CLI provider wiring 已在仓库落地，验证多源 provider 主路径可行
 - GitHub 工作流治理已补齐：`develop` / `master` 受保护，已开启合并后自动删分支
+
+### Milestone A 完成项 (2026-03-13)
+
+- `@loamlog/sanitizer` — 日志脱敏硬前置层，支持 API Key/Token/邮箱/手机号识别与语义占位替换
+- `@loamlog/trigger` — 智能触发管道，支持阈值触发、异步批处理、限流降级
+- `@loamlog/evaluation-harness` — 质量评估框架，支持信号提取与 Issue 草稿质量评测
+- Issue #26, #22, #23 已完成并关闭；PR #39, #41, #37 已合并到 `develop`
 
 ### 当前产品聚焦说明 | Current Product Focus Note
 
@@ -118,6 +131,38 @@ M4 执行计划仍保留为参考文档，但不再代表当前唯一焦点。
 2. provider 不可用时有明确错误提示
 
 详细执行计划 / Detailed execution plan: `AIEF/context/business/m3-execution-plan.md`
+
+---
+
+## Milestone A：可信底盘 | Trust Infrastructure
+
+**目标 / Goal**: 让 Loamlog 能在真实日志上安全运行，建立可验证的质量基准。
+
+**交付 / Deliverables**:
+- `packages/sanitizer` — 日志脱敏硬前置层
+  - 敏感信息识别与语义占位替换
+  - 审计摘要生成（数量、类型分布、风险等级）
+  - 支持 API Key/Token/邮箱/手机号等多种模式
+  
+- `packages/trigger` — 智能触发管道
+  - 阈值触发机制（频率/严重度/语义/人工）
+  - 异步批处理与性能隔离
+  - 限流、降级、熔断基础机制
+  
+- `packages/evaluation-harness` — 质量评估框架
+  - 信号提取准确性评测
+  - Issue 草稿质量评估
+  - 支持不同规则/提示词/模型版本对比
+
+**验收 / Acceptance**:
+1. 原始日志在进入 AI 前已脱敏
+2. AI 分析异步、可限流、可降级
+3. 能用样本集评估提炼质量
+
+**完成状态 / Status**: ✅ 已完成 (2026-03-13)
+- Issue #26 → PR #39 (sanitizer)
+- Issue #22 → PR #41 (trigger)
+- Issue #23 → PR #37 (evaluation-harness)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,17 @@ Cursor*      ──►  redaction            multi-distiller       notion*
 
 ## Current Direction
 
-As of 2026-03-10, Loamlog already has a runnable local-first pipeline for capture, archive, and distill. The repo also contains the second provider family (`claude-code`) on the source side; the main product question is no longer "can the abstractions exist?" but "what is the first flow that creates obvious day-one value?"
+As of 2026-03-13, Loamlog has completed **Milestone A: Trust Infrastructure**, adding three critical capabilities:
 
-- **Shipped today** — capture, archive, redaction, evidence-backed distill, and file-based local output are all present in the repo
-- **Current product focus** — tighten the first killer flow: `AI conversation -> issue draft`, starting with local JSON + Markdown output before any GitHub API delivery
-- **Planned next infrastructure work** — continue hardening multi-source provider support and deferred CLI/docs items without letting them displace the first product loop
+- **Sanitization Gateway** — sensitive data redaction before AI processing
+- **Triggered Intelligence Pipeline** — threshold-based, async, rate-limited distill
+- **Evaluation Harness** — quality metrics for distill accuracy
+
+The main product question is now: "Is the first flow stable enough to justify Stage 2 automation?"
+
+- **Shipped today** — capture, archive, redaction, trigger, evidence-backed distill, evaluation, and file-based local output
+- **Current product focus** — stabilize the first killer flow: `AI conversation -> structured evidence -> local issue draft`
+- **Planned next** — MCP Exposure Layer design (Milestone B) and GitHub API sink (Stage 2)
 
 ---
 
@@ -63,6 +69,9 @@ loamlog/
 ├── packages/
 │   ├── core/               # Core types & interface contracts
 │   ├── archive/            # Unified storage (write / redact / fingerprint)
+│   ├── sanitizer/          # Log sanitization gateway (Milestone A)
+│   ├── trigger/            # Triggered intelligence pipeline (Milestone A)
+│   ├── evaluation-harness/ # Quality evaluation framework (Milestone A)
 │   ├── providers/
 │   │   ├── opencode/       # OpenCode data source adapter
 │   │   └── claude-code/    # Claude Code transcript adapter
@@ -84,6 +93,7 @@ loamlog/
 | M1 | Capture layer MVP — auto-archive sessions | ✅ Completed |
 | M2 | Distill platform MVP — pitfall-card distiller | ✅ Completed |
 | M3 | Multi-model LLM routing | ✅ Completed |
+| **Milestone A** | **Trust Infrastructure** — sanitization, trigger, evaluation | ✅ **Completed** |
 | M4 | Multi-source providers (Claude Code, ...) | ◐ Landed in repo, needs follow-up hardening |
 | M5 | Ecosystem — sinks, approve flow, more distillers | ⏳ Planned |
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -48,11 +48,17 @@ Cursor*      ──►  脱敏处理             多 distiller          notion*
 
 ## 当前方向
 
-截至 2026-03-10，Loamlog 已具备本地优先的 capture、archive、distill 可运行闭环。仓库中也已经包含第二类 provider（`claude-code`）的主路径实现；当前真正要回答的问题，不再只是“抽象能否成立”，而是“第一条让用户立刻感知价值的产品闭环是什么”。
+截至 2026-03-13，Loamlog 已完成 **里程碑 A：可信底盘**，新增三项关键能力：
 
-- **今天已具备**：采集、归档、脱敏、evidence-backed distill，以及本地文件输出主路径都已在仓库中存在
-- **当前产品焦点**：收敛首个 Killer Flow：`AI conversation -> issue draft`，先做本地 JSON + Markdown 输出，再考虑 GitHub API 自动投递
-- **后续基础设施工作**：继续补强多源 provider 与延期的 CLI/docs 项，但不再让它们盖过第一条产品闭环
+- **脱敏网关** — AI 处理前的敏感数据脱敏
+- **智能触发管道** — 基于阈值的异步、限流萃取
+- **评估框架** — 萃取质量指标
+
+当前真正要回答的问题是："第一条产品闭环是否足够稳定，可以进入第二阶段自动化？"
+
+- **今天已具备**：采集、归档、脱敏、触发、evidence-backed distill、评估，以及本地文件输出
+- **当前产品焦点**：稳定首个 Killer Flow：`AI conversation -> structured evidence -> local issue draft`
+- **下一步**：MCP Exposure Layer 设计（里程碑 B）和 GitHub API sink（第二阶段）
 
 ---
 
@@ -63,6 +69,9 @@ loamlog/
 ├── packages/
 │   ├── core/               # 核心 TypeScript 类型与接口契约
 │   ├── archive/            # 统一存储（写入 / 脱敏 / 指纹）
+│   ├── sanitizer/          # 日志脱敏网关（里程碑 A）
+│   ├── trigger/            # 智能触发管道（里程碑 A）
+│   ├── evaluation-harness/ # 质量评估框架（里程碑 A）
 │   ├── providers/
 │   │   ├── opencode/       # OpenCode 数据源适配器
 │   │   └── claude-code/    # Claude Code transcript 适配器
@@ -84,6 +93,7 @@ loamlog/
 | M1 | 采集层 MVP — 自动归档会话 | ✅ 已完成 |
 | M2 | 萃取层 MVP — pitfall-card distiller | ✅ 已完成 |
 | M3 | 多模型 LLM 路由 | ✅ 已完成 |
+| **里程碑 A** | **可信底盘** — 脱敏、触发、评估 | ✅ **已完成** |
 | M4 | 多数据源接入（Claude Code 等） | ◐ 主路径已落地，需继续补强 |
 | M5 | 生态化 — Sink、审批流、更多 distiller | ⏳ 规划中 |
 


### PR DESCRIPTION
## Summary

更新 README.md 文档，反映 Milestone A 的完成情况。

## Changes

### 1. Project Structure
添加了 Milestone A 的三个新包：
- packages/sanitizer/ — 日志脱敏网关
- packages/trigger/ — 智能触发管道
- packages/evaluation-harness/ — 质量评估框架

### 2. Current Status
新增 Milestone A (Trust Infrastructure) 行，标记为 ✅ Completed

### 3. Current Direction
- 更新日期为 2026-03-13
- 突出 Milestone A 的三个核心能力
- 明确下一阶段方向：Milestone B (MCP Exposure Layer)

## Checklist

- [x] README 结构图已更新
- [x] Milestone 表格已更新
- [x] Current Direction 已更新
- [x] 新包已正确标注

## Related

- Milestone A: Trust Infrastructure (completed)
- Issues: #26, #22, #23
- PRs: #39, #41