### PR TITLE
docs: sync project status and MCP design direction

### DIFF
--- a/AIEF/context/business/current-focus.md
+++ b/AIEF/context/business/current-focus.md
@@ -28,6 +28,8 @@ AI conversation -> structured evidence -> local issue draft
 
 ## 当前活跃议题 | Current Active Threads
 
+- `#24` — MCP Exposure Layer：作为 Milestone B 的设计入口，当前已在 `AIEF/openspec/mcp-exposure-layer.md` 固化 design-first / mapping-first 边界，但尚不进入完整 MCP Server 实现
+- `#24` — MCP Exposure Layer: now has a formal boundary spec at `AIEF/openspec/mcp-exposure-layer.md`; it is an active Milestone B design track, not a full MCP server implementation effort yet
 - `#5` — umbrella：zero-config discovery 方向
 - `#9` / `#10` / `#11` — 作为后续 discovery 研究与规格拆分
 - `#6` — Auto-Skill Generation，保留为 later-stage idea
@@ -60,6 +62,8 @@ There are no longer active implementation issues for the first issue-draft MVP l
 - issue-draft 输出是否足够稳定、可复用、可读
 - 用户是否真的会把本地 `.md` 草稿复制进 GitHub
 - 是否已经值得推进 Stage 2 的自动化项（例如 GitHub API sink）
+- 是否先继续推进 #24 的协议边界细化（例如 request/response shape 与 auth tier），而不是直接重投入服务端实现
+- Whether to continue refining the #24 protocol boundary (for example request/response shapes and auth tiers) before committing to any MCP server implementation
 
 ### `#5` umbrella
 

--- a/AIEF/context/business/current-focus.md
+++ b/AIEF/context/business/current-focus.md
@@ -62,7 +62,7 @@ There are no longer active implementation issues for the first issue-draft MVP l
 - issue-draft 输出是否足够稳定、可复用、可读
 - 用户是否真的会把本地 `.md` 草稿复制进 GitHub
 - 是否已经值得推进 Stage 2 的自动化项（例如 GitHub API sink）
-- 是否先继续推进 #24 的协议边界细化（例如 request/response shape 与 auth tier），而不是直接重投入服务端实现
+- 是否先继续推进 #24 的协议边界细化（例如 request/response shapes 与 auth tiers），而不是直接重投入服务端实现
 - Whether to continue refining the #24 protocol boundary (for example request/response shapes and auth tiers) before committing to any MCP server implementation
 
 ### `#5` umbrella

--- a/AIEF/context/business/roadmap.md
+++ b/AIEF/context/business/roadmap.md
@@ -66,6 +66,16 @@ AI conversation -> structured evidence -> local issue draft
 
 M4 执行计划仍保留为参考文档，但不再代表当前唯一焦点。
 
+同时，Milestone B 的协议化方向已经有了第一份正式边界规格：
+
+- Issue #24（MCP Exposure Layer）已通过 PR #52 落地设计边界文档：`AIEF/openspec/mcp-exposure-layer.md`
+- 当前含义是“先明确 resource/tool/prompt 映射与安全边界”，而不是立即投入完整 MCP Server 实现
+
+At the same time, Milestone B's protocol direction now has its first formal boundary spec:
+
+- Issue #24 (MCP Exposure Layer) now has an in-repo boundary document via PR #52: `AIEF/openspec/mcp-exposure-layer.md`
+- The current meaning is design-first protocol mapping and safety boundaries, not immediate investment in a full MCP server implementation
+
 ---
 
 ## M0：验证阶段 | Validation
@@ -181,7 +191,7 @@ M4 执行计划仍保留为参考文档，但不再代表当前唯一焦点。
 3. 通过 loam capture 或 daemon 触发的 Claude Code 会话，归档 snapshot 的 .meta.provider 字段值为 "claude-code"
 4. Claude Code provider 与 OpenCode provider 可并行采集，互不干扰，归档路径结构完全一致
 
-详细执行计划 / Detailed execution plan: `AIEF/context/business/m4-execution-plan.md`
+参考执行计划 / Reference execution plan: `AIEF/context/business/m4-execution-plan.md`
 
 状态说明 / Status note:
 

--- a/AIEF/context/business/roadmap.md
+++ b/AIEF/context/business/roadmap.md
@@ -68,12 +68,12 @@ M4 执行计划仍保留为参考文档，但不再代表当前唯一焦点。
 
 同时，Milestone B 的协议化方向已经有了第一份正式边界规格：
 
-- Issue #24（MCP Exposure Layer）已通过 PR #52 落地设计边界文档：`AIEF/openspec/mcp-exposure-layer.md`
+- Issue #24（MCP Exposure Layer）现已形成仓库内设计边界文档：`AIEF/openspec/mcp-exposure-layer.md`
 - 当前含义是“先明确 resource/tool/prompt 映射与安全边界”，而不是立即投入完整 MCP Server 实现
 
 At the same time, Milestone B's protocol direction now has its first formal boundary spec:
 
-- Issue #24 (MCP Exposure Layer) now has an in-repo boundary document via PR #52: `AIEF/openspec/mcp-exposure-layer.md`
+- Issue #24 (MCP Exposure Layer) now has an in-repo boundary document: `AIEF/openspec/mcp-exposure-layer.md`
 - The current meaning is design-first protocol mapping and safety boundaries, not immediate investment in a full MCP server implementation
 
 ---

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The main product question is now: "Is the first flow stable enough to justify St
 
 - **Shipped today** — capture, archive, redaction, trigger, evidence-backed distill, evaluation, and file-based local output
 - **Current product focus** — stabilize the first killer flow: `AI conversation -> structured evidence -> local issue draft`
-- **Planned next** — MCP Exposure Layer design (Milestone B) and GitHub API sink (Stage 2)
+- **Planned next** — MCP Exposure Layer design (Milestone B), now anchored by `AIEF/openspec/mcp-exposure-layer.md`, and GitHub API sink (Stage 2)
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -58,7 +58,7 @@ Cursor*      ──►  脱敏处理             多 distiller          notion*
 
 - **今天已具备**：采集、归档、脱敏、触发、evidence-backed distill、评估，以及本地文件输出
 - **当前产品焦点**：稳定首个 Killer Flow：`AI conversation -> structured evidence -> local issue draft`
-- **下一步**：MCP Exposure Layer 设计（里程碑 B）和 GitHub API sink（第二阶段）
+- **下一步**：MCP Exposure Layer 设计（里程碑 B，边界规格已落在 `AIEF/openspec/mcp-exposure-layer.md`）和 GitHub API sink（第二阶段）
 
 ---
 


### PR DESCRIPTION
## Summary
- sync top-level and business-facing docs with the current product focus around the local issue-draft loop
- record that Milestone B MCP work now has an in-repo boundary spec at `AIEF/openspec/mcp-exposure-layer.md`
- keep roadmap and current-focus docs aligned on design-first MCP scope rather than premature server implementation

## Why
These updates keep the public and internal status entrypoints consistent with the repository's current state after the MCP boundary spec work landed.

## Related
- #24