### PR TITLE
docs: clean up plan lifecycle and reference statuses

### DIFF
--- a/AIEF/context/INDEX.md
+++ b/AIEF/context/INDEX.md
@@ -13,7 +13,7 @@ Project long-term context navigation entry.
 | [current-focus.md](business/current-focus.md) | 当前产品焦点、已完成 MVP 状态、下一阶段判断点 / Current product focus, completed MVP state, next-phase decision points | 活跃 / Active |
 | [decisions.md](business/decisions.md) | 架构决策记录（ADR）与依据 / Architecture decision records with rationale | 活跃 / Active |
 | [roadmap.md](business/roadmap.md) | 里程碑、交付物、验收标准 / Milestones, deliverables, acceptance criteria | 活跃 / Active |
-| [m3-execution-plan.md](business/m3-execution-plan.md) | M3 多模型路由执行计划与 OpenCode 手工验证清单 / M3 multi-provider execution plan and OpenCode manual verification checklist | 活跃 / Active |
+| [m3-execution-plan.md](business/m3-execution-plan.md) | M3 多模型路由执行计划与 OpenCode 手工验证清单 / M3 multi-provider execution plan and OpenCode manual verification checklist | 参考 / Reference |
 | [m4-execution-plan.md](business/m4-execution-plan.md) | M4 Claude Code provider 执行计划与手工验证清单 / M4 Claude Code provider execution plan and manual verification checklist | 参考 / Reference |
 
 ### tech/ - 架构、集成、契约 | Architecture, integrations, contracts
@@ -38,7 +38,7 @@ Project long-term context navigation entry.
 | 文件 / File | 说明 / Description | 状态 / Status |
 |---|---|---|
 | [2026-03-10-issue-draft-mvp.md](../plans/2026-03-10-issue-draft-mvp.md) | issue-draft MVP 的分步执行计划 / Step-by-step implementation plan for issue-draft MVP | 参考 / Reference |
-| [2026-03-11-distill-builtins-decoupling.md](../plans/2026-03-11-distill-builtins-decoupling.md) | `@loamlog/distill` 与内置插件解耦计划 / Decoupling plan for `@loamlog/distill` and built-in plugins | 活跃 / Active |
+| [2026-03-11-distill-builtins-decoupling.md](../plans/2026-03-11-distill-builtins-decoupling.md) | `@loamlog/distill` 与内置插件解耦计划 / Decoupling plan for `@loamlog/distill` and built-in plugins | 参考 / Reference |
 
 ### ../openspec/ - 最小规格层 | Minimal Spec Layer
 
@@ -46,3 +46,6 @@ Project long-term context navigation entry.
 |---|---|---|
 | [README.md](../openspec/README.md) | OpenSpec 层说明与使用边界 / OpenSpec purpose and usage boundary | 已建立 / Established |
 | [current-focus.md](../openspec/current-focus.md) | 当前产品焦点、完成态与下一阶段判断点 / Current product focus, completed state, and next-phase decision points | 活跃 / Active |
+| [distill-builtins-boundary.md](../openspec/distill-builtins-boundary.md) | 内置 distiller/sink 与 CLI bootstrap 的边界规格 / Boundary spec for built-in distiller/sink ownership and CLI bootstrap | 活跃 / Active |
+| [issue-draft-module-boundary.md](../openspec/issue-draft-module-boundary.md) | `@loamlog/distiller-issue-draft` 的内部模块拆分边界 / Internal module boundary for `@loamlog/distiller-issue-draft` | 活跃 / Active |
+| [mcp-exposure-layer.md](../openspec/mcp-exposure-layer.md) | Issue #24 的 MCP 暴露层边界规格：先定义 resource/tool/prompt 映射，再决定是否实现服务端 / Boundary spec for Issue #24 MCP exposure: define resource/tool/prompt mapping before any server implementation | 活跃 / Active |

--- a/AIEF/context/business/m4-execution-plan.md
+++ b/AIEF/context/business/m4-execution-plan.md
@@ -1,15 +1,21 @@
 # M4 执行计划（M3 完成后） | M4 Execution Plan (Post-M3)
 
-> **Status:** Reference / Partially Landed
+> **状态 | Status:** 参考 / 部分落地 | Reference / Partially Landed
 >
+> 本文档已不再是当前项目的主要推进焦点。
 > This document is no longer the active project focus.
 >
+> M4 的主路径已经在仓库中完成落地：
 > The main M4 path has already landed in the repository:
 >
+> - `packages/providers/claude-code` 已在仓库内存在
 > - `packages/providers/claude-code` exists in-tree
+> - 面向多源捕获的 CLI / provider 接线已经完成
 > - CLI/provider wiring for multi-source capture has landed
+> - 当前剩余工作主要是加固、验证与文档恢复，而不是从零开始的新实现
 > - current remaining work is hardening, verification, and documentation recovery rather than greenfield implementation
 >
+> 请将此文件保留为历史执行上下文与验证参考，而不是当前的主要执行清单。
 > Keep this file as historical execution context and validation reference, not as the current primary execution checklist.
 
 ## 背景 | Background

--- a/AIEF/context/business/m4-execution-plan.md
+++ b/AIEF/context/business/m4-execution-plan.md
@@ -1,5 +1,17 @@
 # M4 执行计划（M3 完成后） | M4 Execution Plan (Post-M3)
 
+> **Status:** Reference / Partially Landed
+>
+> This document is no longer the active project focus.
+>
+> The main M4 path has already landed in the repository:
+>
+> - `packages/providers/claude-code` exists in-tree
+> - CLI/provider wiring for multi-source capture has landed
+> - current remaining work is hardening, verification, and documentation recovery rather than greenfield implementation
+>
+> Keep this file as historical execution context and validation reference, not as the current primary execution checklist.
+
 ## 背景 | Background
 
 M3（多模型 LLM 路由）已完成并发布，`master` 与 `develop` 已同步。下一阶段进入 M4：多源 Provider 扩展，目标是在不改 capture 层核心逻辑的前提下接入第二个 AI 工具（Claude Code），验证 `ProviderAdapter` 接口的可扩展性。

--- a/AIEF/plans/2026-03-10-issue-draft-mvp.md
+++ b/AIEF/plans/2026-03-10-issue-draft-mvp.md
@@ -1,5 +1,11 @@
 # Issue Draft MVP Implementation Plan
 
+> **Status:** Completed / Reference
+>
+> This plan has already been executed. The local-first issue-draft loop now exists in the repository and the corresponding MVP thread has been closed in GitHub (`#7`, `#12`, `#13`, `#14`).
+>
+> Keep this file as historical implementation context, not as an active execution checklist.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Build the first local-first issue-draft flow so a single archived AI session can produce an evidence-backed GitHub-ready draft as `.json` plus `.md`.

--- a/AIEF/plans/2026-03-11-distill-builtins-decoupling.md
+++ b/AIEF/plans/2026-03-11-distill-builtins-decoupling.md
@@ -1,5 +1,15 @@
 # Distill Built-ins Decoupling Implementation Plan
 
+> **Status:** Completed / Reference
+>
+> The intended boundary in this plan is already reflected in the current repository state:
+>
+> - `@loamlog/distill` no longer owns direct built-in distiller/sink dependencies
+> - `@loamlog/cli` owns built-in plugin availability for default CLI execution
+> - built-in specifier normalization now happens in the CLI layer
+>
+> Keep this file as historical implementation context. The active architectural boundary now lives in `AIEF/openspec/distill-builtins-boundary.md`.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Decouple `@loamlog/distill` from direct built-in distiller/sink package dependencies while preserving current runtime plugin loading behavior.


### PR DESCRIPTION
## Summary
- downgrade completed execution plans from active/completed wording into historical reference context
- mark the M4 execution plan as reference-only now that the main path has already landed in-repo
- align `AIEF/context/INDEX.md` status labels with the current documentation lifecycle

## Why
These docs still have value, but they no longer describe the active execution path. This PR reduces confusion in the documentation entrypoints by keeping active status for current focus documents and reference status for historical plans.